### PR TITLE
Fix multiple equal formats error

### DIFF
--- a/lib/membrane/kino/player_sink.ex
+++ b/lib/membrane/kino/player_sink.ex
@@ -131,8 +131,6 @@ defmodule Membrane.Kino.Player.Sink do
 
   @impl true
   def handle_stream_format({_mod, pad, _ref} = pad_ref, stream_format, ctx, state) do
-    IO.inspect(stream_format, label: "stream_format")
-
     if Track.ready?(state.tracks[pad]) do
       input = Map.fetch!(ctx.pads, pad_ref)
 


### PR DESCRIPTION
If multiple, equal formats are given, error is no longer raised